### PR TITLE
fix(ios): crashing on non-string property values

### DIFF
--- a/ios/Plugin/MixpanelPlugin.swift
+++ b/ios/Plugin/MixpanelPlugin.swift
@@ -57,7 +57,7 @@ public class MixpanelPlugin: CAPPlugin {
     }
 
     @objc func registerSuperProperties(_ call: CAPPluginCall) {
-        guard let properties = call.getObject("properties") as! Dictionary<String,String>? else {
+        guard let properties = call.getObject("properties") as? Dictionary<String,MixpanelType>? else {
             return
         }
         Mixpanel.mainInstance().registerSuperProperties(properties)
@@ -65,7 +65,7 @@ public class MixpanelPlugin: CAPPlugin {
     }
 
     @objc func setProfile(_ call: CAPPluginCall) {
-        guard let properties = call.getObject("properties") as! Dictionary<String,String>? else {
+        guard let properties = call.getObject("properties") as? Dictionary<String,MixpanelType>? else {
             return
         }
         Mixpanel.mainInstance().people.set(properties: properties)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houseninja/capacitor-mixpanel",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Capacitor plugin for Mixpanel",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
<img width="538" alt="Screen Shot 2022-03-01 at 1 06 56 PM" src="https://user-images.githubusercontent.com/1849508/156248947-481edd96-1a9b-4ca3-b2ec-2f611c9275eb.png">

fixes #2 