### PR TITLE
fix: iOS extra argument 'serverURL' error

### DIFF
--- a/ios/Plugin/MixpanelPlugin.swift
+++ b/ios/Plugin/MixpanelPlugin.swift
@@ -10,9 +10,13 @@ import Mixpanel
 public class MixpanelPlugin: CAPPlugin {
     public override func load() {
         let token = getConfigValue("iosToken") as? String ?? "ADD_IN_CAPACITOR_CONFIG_JSON"
-        let serverURL = getConfigValue("serverUrl") as? String ?? nil
+        let serverURL = getConfigValue("serverUrl") as? String ?? ""
 
-        Mixpanel.initialize(token: token, serverURL: serverURL)
+        let mixpanel = Mixpanel.initialize(token: token)
+
+        if !serverURL.isEmpty {
+            mixpanel.serverURL = serverURL
+        }
     }
 
     @objc func initialize(_ call: CAPPluginCall) {


### PR DESCRIPTION
Fixes the following error when building a Capacitor project for iOS that includes capacitor-mixpanel:
```
MixpanelPlugin.swift:15:54: error: extra argument 'serverURL' in call
Mixpanel.initialize(token: token, serverURL: serverURL)
```

I haven't tested building with serverURL config set but have followed Mixpanel's Swift SDK instructions:
https://developer.mixpanel.com/docs/swift#eu-data-residency