### PR TITLE
WIP: [ios] Get optInTracking & optOutTracking working

### DIFF
--- a/ios/Plugin/MixpanelPlugin.m
+++ b/ios/Plugin/MixpanelPlugin.m
@@ -17,4 +17,6 @@ CAP_PLUGIN(MixpanelPlugin, "Mixpanel",
            CAP_PLUGIN_METHOD(setProfileUnion, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(trackCharge, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(flush, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(optInTracking, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(optOutTracking, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/MixpanelPlugin.swift
+++ b/ios/Plugin/MixpanelPlugin.swift
@@ -108,11 +108,15 @@ public class MixpanelPlugin: CAPPlugin {
     }
     
     @objc func optInTracking(_ call: CAPPluginCall) {
+        // TO DO: Get optInTracking working either with or without these parameters set
+        /*
         let distinctId: String = call.getString("distinctId")!
         guard let properties = call.getObject("properties") as? Properties else {
             return
         }
         Mixpanel.mainInstance().optInTracking(distinctId: distinctId, properties: properties)
+        */
+        Mixpanel.mainInstance().optInTracking()
         call.resolve()
     }
     


### PR DESCRIPTION
As far as I can tell neither optOutTracking nor optInTracking currently work in iOS. (Trying either results in an error.)

This fix gets optOutTracking working, and optInTracking working also **if no arguments are set**. It still needs to be tweaked to work with the OptInOptions "distinctId" and "properties".