### PR TITLE
feat: support dynamic mixpanel initialize call for Android & iOS

### DIFF
--- a/android/src/main/java/co/houseninja/plugins/mixpanel/MixpanelPlugin.java
+++ b/android/src/main/java/co/houseninja/plugins/mixpanel/MixpanelPlugin.java
@@ -23,9 +23,11 @@ public class MixpanelPlugin extends Plugin {
         boolean trackAutomaticEvents = getConfig().getBoolean("trackAutomaticEvents", true);
         boolean optOutTrackingByDefault = getConfig().getBoolean("optOutTrackingByDefault", false);
 
-        mixpanel = MixpanelAPI.getInstance(getContext(), token, optOutTrackingByDefault, trackAutomaticEvents);
+        if (token != null) {
+            mixpanel = MixpanelAPI.getInstance(getContext(), token, optOutTrackingByDefault, trackAutomaticEvents);
+        }
 
-        if (serverUrl != null) {
+        if (serverUrl != null && mixpanel != null) {
             mixpanel.setServerURL(serverUrl);
         }
 
@@ -35,7 +37,18 @@ public class MixpanelPlugin extends Plugin {
 
     @PluginMethod
     public void initialize(PluginCall call) {
-        call.unimplemented("Not implemented on Android. Mixpanel is initialized automatically.");
+        String token = call.getString("token");
+        String serverUrl = call.getString("serverUrl", "https://api.mixpanel.com");
+        boolean trackAutomaticEvents = call.getBoolean("trackAutomaticEvents", true);
+        boolean optOutTrackingByDefault = call.getBoolean("optOutTrackingByDefault", false);
+
+        mixpanel = MixpanelAPI.getInstance(getContext(), token, optOutTrackingByDefault, trackAutomaticEvents);
+
+        if (serverUrl != null && mixpanel != null) {
+            mixpanel.setServerURL(serverUrl);
+        }
+
+        call.resolve();
     }
 
     @PluginMethod

--- a/ios/Plugin/MixpanelPlugin.swift
+++ b/ios/Plugin/MixpanelPlugin.swift
@@ -15,6 +15,24 @@ public class MixpanelPlugin: CAPPlugin {
         let trackAutomaticEvents = getConfig().getBoolean("trackAutomaticEvents", true)
         let disableIpCollection = getConfig().getBoolean("disableIosIpCollection", false)
 
+        if (token != "MIXPANEL_TOKEN_REQUIRED") {
+            let instance = Mixpanel.initialize(
+                token: token,
+                trackAutomaticEvents: trackAutomaticEvents,
+                optOutTrackingByDefault: optOutTrackingByDefault,
+                serverURL: serverURL
+            )
+            instance.useIPAddressForGeoLocation = !disableIpCollection
+        }
+    }
+
+    @objc func initialize(_ call: CAPPluginCall) {
+        let token = call.getString("token") ?? "MIXPANEL_TOKEN_REQUIRED"
+        let serverURL = call.getString("serverUrl", "https://api.mixpanel.com")
+        let optOutTrackingByDefault = call.getBool("optOutTrackingByDefault", false)
+        let trackAutomaticEvents = call.getBool("trackAutomaticEvents", true)
+        let disableIpCollection = call.getBool("disableIosIpCollection", false)
+
         let instance = Mixpanel.initialize(
             token: token,
             trackAutomaticEvents: trackAutomaticEvents,
@@ -22,10 +40,8 @@ public class MixpanelPlugin: CAPPlugin {
             serverURL: serverURL
         )
         instance.useIPAddressForGeoLocation = !disableIpCollection
-    }
 
-    @objc func initialize(_ call: CAPPluginCall) {
-        call.unimplemented("Not implemented on iOS. Mixpanel is initialized automatically.")
+        call.resolve()
     }
 
     @objc func distinctId(_ call: CAPPluginCall) {


### PR DESCRIPTION
addresses #230 

Allow Mixpanel to be initialized at runtime instead of on app startup. This allows more flexibility in getting the configuration from the environment or other sources.

The token, server URL, and other options are now passed to the initialize() method instead of being hardcoded in `capacitor.conf` This better supports initializing Mixpanel only when needed, rather than always on app startup.